### PR TITLE
Update exception error message handling.

### DIFF
--- a/doubles/verification.py
+++ b/doubles/verification.py
@@ -47,4 +47,4 @@ def verify_arguments(target, method_name, args, kwargs):
     try:
         getcallargs(method, *args, **kwargs)
     except TypeError as e:
-        raise VerifyingDoubleArgumentError(e.message)
+        raise VerifyingDoubleArgumentError(str(e))


### PR DESCRIPTION
As of python 2.6, using Exception.message is deprecated.  This is a
result of PEP 352.  More info:

http://legacy.python.org/dev/peps/pep-0352/
http://stackoverflow.com/questions/1272138/baseexception-message-deprecated-in-python-2-6
