### PR TITLE
Unable to double top level function when called through a func set dict.

### DIFF
--- a/doubles/testing.py
+++ b/doubles/testing.py
@@ -50,3 +50,7 @@ def top_level_function(arg1, arg2='default'):
         arg1=arg1,
         arg2=arg2
     )
+
+func_set = {
+    'top_level_function': top_level_function
+}

--- a/test/partial_double_test.py
+++ b/test/partial_double_test.py
@@ -189,3 +189,17 @@ class TestTopLevelFunctions(object):
     def test_verifies_the_function_exists(self):
         with raises(VerifyingDoubleError):
             allow(doubles.testing).fake_function
+
+    def test_can_be_called_through_dict(self):
+        allow(doubles.testing).top_level_function.with_args(
+            'charles',
+            'barkley'
+        ).and_return('baz')
+
+        # accessing the function directly works
+        # func = doubles.testing.top_level_function
+
+        # but accessing it through a dict in another module fails
+        func = doubles.testing.func_set['top_level_function']
+
+        assert func('charles', 'barkley') == 'baz'


### PR DESCRIPTION
I see this pattern often enough in Python:

``` python
available_adapters = {
  'cookie_adapter': cookie_adapter
}

def cookie_adapter(yom):
    pass

def do_stuff(args):
    if "cookie_adapter" in available_adapters:
        available_adapters["cookie_adapter"](*args)
```

Unfortunately when I try to `allow` cookie_adapter to be called, doubles fails to step in when the subsequent call to `do_stuff` occurs.

I've created a basic test to try and prove out the failure. Let me know if I can help in any way :)
