### PR TITLE
InstanceDouble.__init__ with kwargs

### DIFF
--- a/doubles/instance_double.py
+++ b/doubles/instance_double.py
@@ -74,14 +74,19 @@ class InstanceDouble(ObjectDouble):
     """
     A pure double representing an instance of the target class.
 
+    Any kwargs supplied will be set as attributes on the instance that is
+    created.
+
     ::
 
-        user = InstanceDouble('myapp.User')
+        user = InstanceDouble('myapp.User', name='Bob Barker')
 
     :param str path: The absolute module path to the class.
     """
 
-    def __init__(self, path):
+    def __init__(self, path, **kwargs):
         module_path, class_name = _get_path_components(path)
         module = _get_module(module_path, path)
         self._doubles_target = _get_doubles_target(module, class_name, path)
+        for k, v in kwargs.items():
+            setattr(self, k, v)

--- a/test/instance_double_test.py
+++ b/test/instance_double_test.py
@@ -71,3 +71,8 @@ class TestInstanceDouble(object):
         user = InstanceDouble('doubles.testing.User')
         allow(user).__call__.and_return('bob barker')
         assert user() == 'bob barker'
+
+    def test_passing_kwargs_assings_them_as_attrs(self):
+        user = InstanceDouble('doubles.testing.User', name='Bob Barker')
+
+        assert user.name == 'Bob Barker'


### PR DESCRIPTION
- Allow callers to pass in kwargs which will be assigned to the instance as attributes
