### PR TITLE
nose: fix test result and honor setup hooks

### DIFF
--- a/doubles/nose.py
+++ b/doubles/nose.py
@@ -16,7 +16,7 @@ class NoseIntegration(Plugin):
 
     def prepareTestCase(self, test):
         def wrapped(result):
-            test.test.run()
+            test.test(result)
 
             try:
                 verify()

--- a/test/nose_test.py
+++ b/test/nose_test.py
@@ -15,6 +15,7 @@ def test_nose_plugin():
         def test_expect(self):
             assert 'MockExpectationError' in self.output
             assert 'FAILED (failures=1)' in self.output
+            assert 'Ran 2 tests' in self.output
 
         def makeSuite(self):
             class TestCase(unittest.TestCase):
@@ -23,7 +24,10 @@ def test_nose_plugin():
 
                     expect(subject).instance_method
 
-            return [TestCase()]
+                def test2(self):
+                    pass
+
+            return [TestCase('runTest'), TestCase('test2')]
 
     result = unittest.TestResult()
     TestNosePlugin('test_expect')(result)


### PR DESCRIPTION
This small but powerful change does two things.  First, it passes
the result object to testcases, so failures/successes/etc. are
captured in a way that the calling framework knows about.  Second
instead of calling the testcase's run() method directly, it calls
the test object itself.  This is what the nose framework expects
and allows any defined **call**() methods in the object hierarchy
to perform setup/teardown if they desire.
