### PR TITLE
Fix property stubbing

### DIFF
--- a/doubles/proxy_property.py
+++ b/doubles/proxy_property.py
@@ -1,0 +1,13 @@
+class ProxyProperty(property):
+    def __init__(self, name, original):
+        """
+        :param str name: name of the doubled property
+        :param property original: the original property
+        """
+        self._name = name
+        self._original = original
+
+    def __get__(self, obj, objtype=None):
+        if self._name in obj.__dict__:
+            return obj.__dict__[self._name].__get__(obj, objtype)
+        return self._original.__get__(obj, objtype)

--- a/test/partial_double_test.py
+++ b/test/partial_double_test.py
@@ -62,6 +62,37 @@ class TestInstanceMethods(object):
 
         assert user.some_property('bob') == 'bob'
 
+    def test_stubbing_properties_on_multiple_instances(self, test_class):
+        user_1 = test_class('Bob', 25)
+        user_2 = test_class('Drew', 25)
+
+        allow(user_1).some_property.and_return('Barker')
+        allow(user_2).some_property.and_return('Carey')
+
+        assert user_1.some_property == 'Barker'
+        assert user_2.some_property == 'Carey'
+
+    def test_stubbing_property_does_not_affect_other_instances(self, test_class):
+        user_1 = test_class('Bob', 25)
+        user_2 = test_class('Drew', 25)
+
+        allow(user_1).some_property.and_return('Barker')
+
+        assert user_1.some_property == 'Barker'
+        assert user_2.some_property == 'some_property return value'
+
+    def test_teardown_restores_properties(self, test_class):
+        user_1 = test_class('Bob', 25)
+        user_2 = test_class('Drew', 25)
+
+        allow(user_1).some_property.and_return('Barker')
+        allow(user_2).some_property.and_return('Carey')
+
+        teardown()
+
+        assert user_1.some_property == 'some_property return value'
+        assert user_2.some_property == 'some_property return value'
+
 
 @mark.parametrize('test_class', [User, OldStyleUser])
 class Test__call__(object):


### PR DESCRIPTION
- resolve #45
- Proxy property form the class back to the instance much like we do
  with **call**
- We may want handle generic datadescriptors/non-datadescriptors 
  we can cross that bridge when we come to it. 
