### PR TITLE
Making mocking callable objects easier

### DIFF
--- a/doubles/target.py
+++ b/doubles/target.py
@@ -6,6 +6,12 @@ from doubles.object_double import ObjectDouble
 ModuleAttribute = namedtuple('ModuleAttribute', ['object', 'kind', 'defining_class'])
 
 
+def _is_callable(obj):
+    if isfunction(obj):
+        return True
+    return hasattr(obj, '__call__')
+
+
 def _proxy_class_method_to_instance(original, name):
     def func(instance, *args, **kwargs):
         if name in instance.__dict__:
@@ -84,7 +90,7 @@ class Target(object):
         attrs = {}
 
         if ismodule(self.doubled_obj):
-            for name, func in getmembers(self.doubled_obj, isfunction):
+            for name, func in getmembers(self.doubled_obj, _is_callable):
                 attrs[name] = ModuleAttribute(func, 'toplevel', self.doubled_obj)
         else:
             for attr in classify_class_attrs(self.doubled_obj_type):

--- a/doubles/testing.py
+++ b/doubles/testing.py
@@ -61,3 +61,34 @@ class ClassWithGetAttr(object):
 
     def __getattr__(self, name):
         return 'attr {name}'.format(name=name)
+
+
+class Callable(object):
+    def __call__(self, arg1):
+        return arg1
+
+
+def return_callable(func):
+    return Callable()
+
+
+def decorate_me(func):
+    def decorated(arg1):
+        return '{arg1} decorated'.format(arg1=arg1)
+
+    return decorated
+
+
+@return_callable
+def decorated_function_callable(arg1):
+    return arg1
+
+
+@decorate_me
+def decorated_function(arg1):
+    return arg1
+
+callable_variable = Callable()
+
+class_method = User.class_method
+instance_method = User('Bob', 25).get_name

--- a/doubles/verification.py
+++ b/doubles/verification.py
@@ -50,7 +50,10 @@ def verify_arguments(target, method_name, args, kwargs):
     method = attr.object
 
     if attr.kind in ('toplevel', 'class method', 'static method'):
-        method = attr.object.__get__(None, attr.defining_class)
+        try:
+            method = method.__get__(None, attr.defining_class)
+        except AttributeError:
+            method = method.__call__
     elif attr.kind == 'property':
         if args or kwargs:
             raise VerifyingDoubleArgumentError("Properties do not accept arguments.")

--- a/test/partial_double_test.py
+++ b/test/partial_double_test.py
@@ -221,6 +221,31 @@ class TestTopLevelFunctions(object):
         with raises(VerifyingDoubleError):
             allow(doubles.testing).fake_function
 
+    def test_callable_top_level_variable(self):
+        allow(doubles.testing).callable_variable.and_return('foo')
+
+        assert doubles.testing.callable_variable('bob barker') == 'foo'
+
+    def test_decorated_function(self):
+        allow(doubles.testing).decorated_function_callable.and_return('foo')
+
+        assert doubles.testing.decorated_function_callable('bob barker') == 'foo'
+
+    def test_decorated_function_that_returns_a_callable(self):
+        allow(doubles.testing).decorated_function.and_return('foo')
+
+        assert doubles.testing.decorated_function('bob barker') == 'foo'
+
+    def test_varibale_that_points_to_class_method(self):
+        allow(doubles.testing).class_method.and_return('foo')
+
+        assert doubles.testing.class_method('bob barker') == 'foo'
+
+    def test_varibale_that_points_to_instance_method(self):
+        allow(doubles.testing).instance_method.and_return('foo')
+
+        assert doubles.testing.instance_method() == 'foo'
+
 
 class TestClassWithGetAtter(object):
     def test_can_allow_an_existing_method(self):


### PR DESCRIPTION
- Fixes #39
- Variables that point to callables can be mocked
- Variables that point to class methods can be mocked
- Variables that point to instance methods can be mocked
- Decorated functions that return callables can be mocked
- Decorated Functions can be mocked
