### PR TITLE
Make argument repr string copyable

### DIFF
--- a/doubles/allowance.py
+++ b/doubles/allowance.py
@@ -23,6 +23,12 @@ def check_func_takes_args(func):
     return arg_spec.args or arg_spec.varargs or arg_spec.keywords or arg_spec.defaults
 
 
+def build_argument_repr_string(args, kwargs):
+    args = [repr(x) for x in args]
+    kwargs = ['{}={!r}'.format(k, v) for k, v in kwargs.items()]
+    return '({})'.format(', '.join(args + kwargs))
+
+
 class Allowance(object):
     """An individual method allowance (stub)."""
 
@@ -271,4 +277,4 @@ class Allowance(object):
         if self.args is _any and self.kwargs is _any:
             return 'any args'
         else:
-            return '(args={!r}, kwargs={!r})'.format(self.args, self.kwargs)
+            return build_argument_repr_string(self.args, self.kwargs)

--- a/doubles/proxy_method.py
+++ b/doubles/proxy_method.py
@@ -4,6 +4,7 @@ import sys
 
 from doubles.exceptions import UnallowedMethodCallError
 from doubles.proxy_property import ProxyProperty
+from doubles.allowance import build_argument_repr_string
 
 double_name = lambda name: 'double_of_' + name
 
@@ -141,13 +142,13 @@ class ProxyMethod(object):
 
         error_message = (
             "Received unexpected call to '{}' on {!r}.  The supplied arguments "
-            "(args={}, kwargs={}) do not match any available allowances."
+            "{} do not match any available allowances."
         )
+
         raise UnallowedMethodCallError(
             error_message.format(
                 self._method_name,
                 self._target.obj,
-                args,
-                kwargs
+                build_argument_repr_string(args, kwargs)
             )
         )

--- a/test/allow_test.py
+++ b/test/allow_test.py
@@ -163,7 +163,24 @@ class TestWithArgs(object):
             r"Received unexpected call to 'method_with_default_args' on "
             r"<InstanceDouble of <class '?doubles.testing.User'?"
             r"(?: at 0x[0-9a-f]{9})?> object at .+>\."
-            r"  The supplied arguments \(args=\(\), kwargs={}\)"
+            r"  The supplied arguments \(\)"
+            r" do not match any available allowances.",
+            str(e.value)
+        )
+
+    def test_raises_if_arguments_were_specified_but_wrong_kwarg_used_when_called(self):
+        subject = InstanceDouble('doubles.testing.User')
+
+        allow(subject).method_with_default_args.with_args('one', bar='two')
+
+        with raises(UnallowedMethodCallError) as e:
+            subject.method_with_default_args('one', bob='barker')
+
+        assert re.match(
+            r"Received unexpected call to 'method_with_default_args' on "
+            r"<InstanceDouble of <class '?doubles.testing.User'?"
+            r"(?: at 0x[0-9a-f]{9})?> object at .+>\."
+            r"  The supplied arguments \('one', bob='barker'\)"
             r" do not match any available allowances.",
             str(e.value)
         )
@@ -180,7 +197,7 @@ class TestWithArgs(object):
             r"Received unexpected call to 'method_with_varargs' on "
             r"<InstanceDouble of <class '?doubles.testing.User'?"
             r"(?: at 0x[0-9a-f]{9})?> object at .+>\."
-            r"  The supplied arguments \(args=\('baz',\), kwargs={}\)"
+            r"  The supplied arguments \('baz'\)"
             r" do not match any available allowances.",
             str(e.value)
         )
@@ -214,7 +231,7 @@ class TestWithNoArgs(object):
             r"Received unexpected call to 'instance_method' on "
             r"<InstanceDouble of <class '?doubles.testing.User'?"
             r"(?: at 0x[0-9a-f]{9})?> object at .+>\."
-            r"  The supplied arguments \(args=\('bar',\), kwargs={}\)"
+            r"  The supplied arguments \('bar'\)"
             r" do not match any available allowances.",
             str(e.value)
         )

--- a/test/expect_test.py
+++ b/test/expect_test.py
@@ -41,7 +41,25 @@ class TestExpect(object):
             r"Expected 'method_with_varargs' to be called on "
             r"<InstanceDouble of <class '?doubles.testing.User'?"
             r"(?: at 0x[0-9a-f]{9})?> object at .+> "
-            r"with \(args=\('bar',\), kwargs={}\), but was not."
+            r"with \('bar'\), but was not."
+            r" \(.*doubles/test/expect_test.py:\d+\)",
+            str(e.value)
+        )
+
+    def test_raises_if_an_expected_method_call_with_default_args_is_not_made(self):
+        subject = InstanceDouble('doubles.testing.User')
+
+        expect(subject).method_with_default_args.with_args('bar', bar='barker')
+
+        with raises(MockExpectationError) as e:
+            verify()
+        teardown()
+
+        assert re.match(
+            r"Expected 'method_with_default_args' to be called on "
+            r"<InstanceDouble of <class '?doubles.testing.User'?"
+            r"(?: at 0x[0-9a-f]{9})?> object at .+> "
+            r"with \('bar', bar='barker'\), but was not."
             r" \(.*doubles/test/expect_test.py:\d+\)",
             str(e.value)
         )

--- a/test/pytest_test.py
+++ b/test/pytest_test.py
@@ -39,7 +39,7 @@ def test_failed_expections_do_not_leak_between_tests(testdir, capsys):
     assert outcomes['failed'] == 2
     expected_error = (
         "*Expected 'class_method' to be called 1 time but was called 0 times on"
-        " <class 'doubles.testing.User'> with (args=('{arg_value}',), kwargs={{}})*"
+        " <class 'doubles.testing.User'> with ('{arg_value}')*"
     )
     result.stdout.fnmatch_lines([expected_error.format(arg_value="test_one")])
     result.stdout.fnmatch_lines([expected_error.format(arg_value="test_two")])


### PR DESCRIPTION
- convert (args=('arg1'), kwargs=(bob='barker')) to ('arg1', bob='barker')
- Fixes #58
