### PR TITLE
Add with_args shorthand

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -58,6 +58,21 @@ The examples shown so far will allow the stubbed method to be called with any ar
         user.set_name('Henry')  # Returns None
         user.set_name('Teddy')  # Raises an UnallowedMethodCallError
 
+You do not need to specifically call ``with_args``, calling the allowance directly is the same as calling ``with_args``.  The following example is identical to the code above::
+
+    from doubles import allow
+
+    from myapp import User
+
+
+    def test_allows_set_name_with_args():
+        user = User('Carl')
+
+        allow(user).set_name('Henry')
+
+        user.set_name('Henry')  # Returns None
+        user.set_name('Teddy')  # Raises an UnallowedMethodCallError
+
 Multiple allowances can be specified for the same method with different arguments and return values::
 
     from doubles import allow

--- a/doubles/allowance.py
+++ b/doubles/allowance.py
@@ -119,6 +119,20 @@ class Allowance(object):
         self.verify_arguments()
         return self
 
+    def __call__(self, *args, **kwargs):
+        """
+        A short hand syntax for with_args
+
+        Allows callers to do:
+            allow(module).foo.with_args(1, 2)
+        With:
+            allow(module).foo(1, 2)
+
+        :param args: Any positional arguments required for invocation.
+        :param kwargs: Any keyword arguments required for invocation.
+        """
+        return self.with_args(*args, **kwargs)
+
     def with_no_args(self):
         """Declares that the double can only be called with no arguments."""
 

--- a/test/allow_test.py
+++ b/test/allow_test.py
@@ -137,6 +137,12 @@ class TestAndReturn(object):
 
 
 class TestWithArgs(object):
+    def test__call__is_short_hand_for_with_args(self):
+        subject = InstanceDouble('doubles.testing.User')
+
+        allow(subject).method_with_positional_arguments('Bob').and_return('Barker')
+        assert subject.method_with_positional_arguments('Bob') == 'Barker'
+
     def test_allows_any_arguments_if_none_are_specified(self):
         subject = InstanceDouble('doubles.testing.User')
 


### PR DESCRIPTION
Shorthand for with_args:

    allow(module).method('foo') == allow(module).method.with_args('foo')