### PR TITLE
Fix schematics issue

### DIFF
--- a/doubles/allowance.py
+++ b/doubles/allowance.py
@@ -147,7 +147,23 @@ class Allowance(object):
         :rtype: bool
         """
 
-        return self.args == args and self.kwargs == kwargs
+        if self.args is _any and self.kwargs is _any:
+            return True
+        if args == self.args and kwargs == self.kwargs:
+            return True
+        elif len(args) != len(self.args) or len(kwargs) != len(self.kwargs):
+            return False
+
+        if not all(x == y or y == x for x, y in zip(args, self.args)):
+            return False
+
+        for key, value in self.kwargs.items():
+            if key not in kwargs:
+                return False
+            elif not (kwargs[key] == value or value == kwargs[key]):
+                return False
+
+        return True
 
     def return_value(self, *args, **kwargs):
         """

--- a/doubles/testing.py
+++ b/doubles/testing.py
@@ -117,3 +117,13 @@ callable_variable = Callable()
 
 class_method = User.class_method
 instance_method = User('Bob', 25).get_name
+
+
+class NeverEquals(object):
+    def __eq__(self, other):
+        return False
+
+
+class AlwaysEquals(object):
+    def __eq__(self, other):
+        return True

--- a/test/allow_test.py
+++ b/test/allow_test.py
@@ -10,6 +10,7 @@ from doubles.exceptions import (
 from doubles.instance_double import InstanceDouble
 from doubles import allow, no_builtin_verification
 from doubles.lifecycle import teardown
+from doubles.testing import AlwaysEquals, NeverEquals
 
 
 class UserDefinedException(Exception):
@@ -44,6 +45,18 @@ class TestBasicAllowance(object):
 
             with raises(VerifyingDoubleArgumentError):
                 subject.instance_method('bar')
+
+    def test_objects_with_custom__eq__method_one(self):
+        subject = InstanceDouble('doubles.testing.User')
+        allow(subject).method_with_positional_arguments.with_args(NeverEquals())
+
+        subject.method_with_positional_arguments(AlwaysEquals())
+
+    def test_objects_with_custom__eq__method_two(self):
+        subject = InstanceDouble('doubles.testing.User')
+        allow(subject).method_with_positional_arguments.with_args(AlwaysEquals())
+
+        subject.method_with_positional_arguments(NeverEquals())
 
 
 class TestReturnValues(object):


### PR DESCRIPTION
* Test with_args with both objects __eq__ method.  This is important for
   using things like equals and mock.Any.

* Feature requested by @UberFarmer 