### PR TITLE
handle arguments when stubbing subclasses of builtins

### DIFF
--- a/doubles/testing.py
+++ b/doubles/testing.py
@@ -131,3 +131,19 @@ class NeverEquals(object):
 class AlwaysEquals(object):
     def __eq__(self, other):
         return True
+
+
+class DictSubClass(dict):
+    pass
+
+
+class ListSubClass(list):
+    pass
+
+
+class SetSubClass(set):
+    pass
+
+
+class TupleSubClass(tuple):
+    pass

--- a/doubles/verification.py
+++ b/doubles/verification.py
@@ -7,6 +7,9 @@ from doubles.exceptions import (
     VerifyingDoubleError,
 )
 
+ACCEPTS_ARGS = (list, tuple, set)
+ACCEPTS_KWARGS = (dict,)
+
 
 if sys.version_info >= (3, 0):
     def _get_func_object(func):
@@ -36,7 +39,12 @@ def _verify_arguments_of_doubles__new__(target, args, kwargs):
     :params dict kwargs: Keyword arguments.
     """
     if not _is_python_function(target.doubled_obj.__init__):
-        if args or kwargs:
+        class_ = target.doubled_obj
+        if args and not kwargs and issubclass(class_, ACCEPTS_ARGS):
+            return True
+        elif kwargs and not args and issubclass(class_, ACCEPTS_KWARGS):
+            return True
+        elif args or kwargs:
             given_args_count = 1 + len(args) + len(kwargs)
             raise VerifyingDoubleArgumentError(
                 '__init__() takes exactly 1 arguments ({} given)'.format(

--- a/test/class_double_test.py
+++ b/test/class_double_test.py
@@ -175,3 +175,37 @@ class TestingStubbingNonClassDoubleConstructors(object):
     def test_raises_if_you_expect_constructor(self, test_class):
         with raises(ConstructorDoubleError):
             expect_constructor(test_class)
+
+
+class TestStubbingConstructorOfBuiltinSubClass(object):
+    @mark.parametrize('type_', ['Dict'])
+    class TestAcceptsKwargs(object):
+        def test_fails_with_positional_args(self, type_):
+            double = ClassDouble('doubles.testing.{}SubClass'.format(type_))
+            with raises(VerifyingDoubleArgumentError):
+                allow_constructor(double).with_args(1, 2)
+
+        def test_fails_with_positional_args_and_kwargs(self, type_):
+            double = ClassDouble('doubles.testing.{}SubClass'.format(type_))
+            with raises(VerifyingDoubleArgumentError):
+                allow_constructor(double).with_args(1, 2, foo=1)
+
+        def test_passes_with_kwargs(self, type_):
+            double = ClassDouble('doubles.testing.{}SubClass'.format(type_))
+            allow_constructor(double).with_args(bob='Barker')
+
+    @mark.parametrize('type_', ['List', 'Set', 'Tuple'])
+    class TestAccpectArgs(object):
+        def test_passes_with_positional_args(self, type_):
+            double = ClassDouble('doubles.testing.{}SubClass'.format(type_))
+            allow_constructor(double).with_args(1, 2)
+
+        def test_fails_with_kwargs(self, type_):
+            double = ClassDouble('doubles.testing.{}SubClass'.format(type_))
+            with raises(VerifyingDoubleArgumentError):
+                allow_constructor(double).with_args(bob='Barker')
+
+        def test_fails_with_positional_args_and_kwargs(self, type_):
+            double = ClassDouble('doubles.testing.{}SubClass'.format(type_))
+            with raises(VerifyingDoubleArgumentError):
+                allow_constructor(double).with_args(1, 2, foo=1)


### PR DESCRIPTION
* allow args for subclasses of: list, tuple, set
* allow kwargs for subclasses of: dict
* fixes #70
* NOTE: This won't solve all cases, but I think it will handle the vast
  majority and is worth it.