### PR TITLE
Replace the use of stack() with a much faster alternative.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,13 @@
 Changelog
 =========
 
+1.1.1 (2015-9-23)
+-----------------
+
+- Optimized suite by using a faster method of retrieving stack frames.
+
 1.1.0 (2015-8-23)
------------
+-----------------
 
 - Native support for futures: `and_return_future` and `and_raise_future`
 

--- a/doubles/__init__.py
+++ b/doubles/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.1.0'
+__version__ = '1.1.1'
 
 from doubles.class_double import ClassDouble  # noqa
 from doubles.instance_double import InstanceDouble  # noqa

--- a/doubles/allowance.py
+++ b/doubles/allowance.py
@@ -335,8 +335,8 @@ class Allowance(object):
                 self._call_counter.error_string(),
                 self._target.obj,
                 self._expected_argument_string(),
-                self._caller[1],
-                self._caller[2]
+                self._caller.filename,
+                self._caller.lineno,
             )
         )
 

--- a/doubles/targets/allowance_target.py
+++ b/doubles/targets/allowance_target.py
@@ -1,4 +1,4 @@
-from inspect import stack
+import inspect
 
 from doubles.lifecycle import current_space
 from doubles.class_double import ClassDouble
@@ -65,5 +65,5 @@ class AllowanceTarget(object):
         if __dict__ and attr_name in __dict__:
             return __dict__[attr_name]
 
-        caller = stack()[1]
+        caller = inspect.getframeinfo(inspect.currentframe().f_back)
         return self._proxy.add_allowance(attr_name, caller)

--- a/doubles/targets/expectation_target.py
+++ b/doubles/targets/expectation_target.py
@@ -1,4 +1,4 @@
-from inspect import stack
+import inspect
 
 from doubles.lifecycle import current_space
 from doubles.class_double import ClassDouble
@@ -63,5 +63,5 @@ class ExpectationTarget(object):
         if __dict__ and attr_name in __dict__:
             return __dict__[attr_name]
 
-        caller = stack()[1]
+        caller = inspect.getframeinfo(inspect.currentframe().f_back)
         return self._proxy.add_expectation(attr_name, caller)


### PR DESCRIPTION
In large code bases, stack() becomes really, *really* expensive. It used
up to 20% of our test run time. This solution is much faster.