### PR TITLE
Support methods added after instance creation

### DIFF
--- a/doubles/proxy_method.py
+++ b/doubles/proxy_method.py
@@ -54,7 +54,7 @@ class ProxyMethod(object):
         self._target = target
         self._method_name = method_name
         self._find_expectation = find_expectation
-        self._attr = target.attrs[method_name]
+        self._attr = target.get_attr(method_name)
 
         self._capture_original_method()
         self._hijack_target()

--- a/doubles/target.py
+++ b/doubles/target.py
@@ -3,7 +3,7 @@ from collections import namedtuple
 
 from doubles.object_double import ObjectDouble
 
-ModuleAttribute = namedtuple('ModuleAttribute', ['object', 'kind', 'defining_class'])
+Attribute = namedtuple('Attribute', ['object', 'kind', 'defining_class'])
 
 
 def _is_callable(obj):
@@ -91,7 +91,7 @@ class Target(object):
 
         if ismodule(self.doubled_obj):
             for name, func in getmembers(self.doubled_obj, _is_callable):
-                attrs[name] = ModuleAttribute(func, 'toplevel', self.doubled_obj)
+                attrs[name] = Attribute(func, 'toplevel', self.doubled_obj)
         else:
             for attr in classify_class_attrs(self.doubled_obj_type):
                 attrs[attr.name] = attr
@@ -138,3 +138,30 @@ class Target(object):
             )
         except AttributeError:
             return None
+
+    def get_callable_attr(self, attr_name):
+        """Used to double methods added to an object after creation
+
+        :param str attr_name: the name of the original attribute to return
+        :return: Attribute or None.
+        :rtype: func
+        """
+
+        if not hasattr(self.doubled_obj, method_name):
+            return None
+
+        func = getattr(self.doubled_obj, method_name)
+        if not _is_callable(func):
+            return None
+
+        attr = Attribute(
+            func,
+            'toplevel',
+            self.doubled_obj if self.is_class() else self.doubled_obj_type,
+        )
+        self.attrs[method_name] = attr
+        return attr
+
+    def get_attr(self, method_name):
+        """Get attribute from the target object"""
+        return self.attrs.get(method_name) or self.get_callable_attr(method_name)

--- a/doubles/target.py
+++ b/doubles/target.py
@@ -147,10 +147,10 @@ class Target(object):
         :rtype: func
         """
 
-        if not hasattr(self.doubled_obj, method_name):
+        if not hasattr(self.doubled_obj, attr_name):
             return None
 
-        func = getattr(self.doubled_obj, method_name)
+        func = getattr(self.doubled_obj, attr_name)
         if not _is_callable(func):
             return None
 
@@ -159,7 +159,7 @@ class Target(object):
             'toplevel',
             self.doubled_obj if self.is_class() else self.doubled_obj_type,
         )
-        self.attrs[method_name] = attr
+        self.attrs[attr_name] = attr
         return attr
 
     def get_attr(self, method_name):

--- a/doubles/testing.py
+++ b/doubles/testing.py
@@ -6,6 +6,10 @@ class EmptyClass(OldStyleEmptyClass, object):
     pass
 
 
+def dummy_function():
+    return 'dummy result'
+
+
 class OldStyleUser():
     """An importable dummy class used for testing purposes."""
 
@@ -14,6 +18,7 @@ class OldStyleUser():
     def __init__(self, name, age):
         self.name = name
         self.age = age
+        self.method_added_after_instance_creation = dummy_function
 
     @staticmethod
     def static_method(arg):

--- a/doubles/verification.py
+++ b/doubles/verification.py
@@ -76,7 +76,7 @@ def verify_method(target, method_name, class_level=False):
         and in the case where the target is a class, that the attribute isn't an instance method.
     """
 
-    attr = target.attrs.get(method_name)
+    attr = target.get_attr(method_name)
 
     if not attr:
         raise VerifyingDoubleError(method_name, target.doubled_obj).no_matching_method()
@@ -101,7 +101,7 @@ def verify_arguments(target, method_name, args, kwargs):
     if method_name == '_doubles__new__':
         return _verify_arguments_of_doubles__new__(target, args, kwargs)
 
-    attr = target.attrs[method_name]
+    attr = target.get_attr(method_name)
     method = attr.object
 
     if attr.kind in ('toplevel', 'class method', 'static method'):

--- a/test/partial_double_test.py
+++ b/test/partial_double_test.py
@@ -13,6 +13,12 @@ import doubles.testing
 
 @mark.parametrize('test_class', [User, OldStyleUser])
 class TestInstanceMethods(object):
+    def test_method_added_after_isntance_creation(self, test_class):
+        user = test_class('Alice', 25)
+        allow(user).method_added_after_instance_creation.and_return('Bob Barker')
+
+        assert user.method_added_after_instance_creation() == 'Bob Barker'
+
     def test_stubs_instance_methods(self, test_class):
         user = test_class('Alice', 25)
 


### PR DESCRIPTION
* When getting an attribute check for it on the instance at call time, and then store it in target.attrs.
* This is needed for methods that are added to an object after it is created
* Motivated by: https://github.com/uber/tchannel-python/blob/master/tchannel/sync/client.py#L86