### PR TITLE
allow hamcrest matchers as arg specs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,6 @@ from setuptools import setup
 from setuptools.command.test import test as TestCommand
 import sys
 
-import doubles
-
 
 with open('README.rst') as f:
     long_description = f.read()
@@ -22,7 +20,7 @@ class PyTest(TestCommand):
 
 setup(
     name='doubles',
-    version=doubles.__version__,
+    version='1.1.3',
     description='Test doubles for Python.',
     long_description=long_description,
     author='Jimmy Cuadra',
@@ -30,6 +28,7 @@ setup(
     url='https://github.com/uber/doubles',
     license='MIT',
     packages=['doubles', 'doubles.targets'],
+    install_requires=['pyhamcrest'],
     tests_require=['pytest'],
     cmdclass={'test': PyTest},
     entry_points = {


### PR DESCRIPTION
Most of the time expectations specify literal parameter values that are compared for equality against the actual parameters of invoked methods. For example:

`allow(calculator).add(2, 2).and_return(5)`

Sometimes, however, you will need to define looser constraints over parameter values to clearly express the intent of the test or to ignore parameters (or parts of parameters) that are not relevant to the behaviour being tested. For example:

``` python
allow(calculator).sqrt(less_than(0)).and_raise(ValueError)
allow(log).append(equal_to(Log.ERROR), contains_string("sqrt"))
```

Loose parameter constraints are defined by specifying matchers for each parameter. Matchers are created by factory functions, such as less_than, equal_to and contains_string in the example above, to ensure that the expectation is easy to read.

See http://www.jmock.org/matchers.html for motivation and details.

Fixes #96 
