### PR TITLE
Fix warning with pytest >= 2.8

### DIFF
--- a/doubles/pytest.py
+++ b/doubles/pytest.py
@@ -1,9 +1,8 @@
 from doubles.lifecycle import teardown, verify
 
 
-def pytest_runtest_call(item, __multicall__):
+def pytest_runtest_call(item):
     try:
-        __multicall__.execute()
         verify()
     finally:
         teardown()


### PR DESCRIPTION
Hello,

This is coming up with pytest ≥ 2.8, not sure how backward compatibility is affected, I just wanted to bring the issue to your attention. (Also, as far as I understand, this is the [right fix](http://pytest.org/latest/writing_plugins.html?highlight=pytest_runtest_call#_pytest.hookspec.pytest_runtest_call)).