### PR TITLE
Fixed questionable grammar from assertion messages

### DIFF
--- a/doubles/call_count_accumulator.py
+++ b/doubles/call_count_accumulator.py
@@ -154,7 +154,7 @@ class CallCountAccumulator(object):
         if self.has_correct_call_count():
             return ''
 
-        return '{} but was called {} {} '.format(
+        return '{} instead of {} {} '.format(
             self._restriction_string(),
             self.count,
             pluralize('time', self.count)

--- a/test/allow_test.py
+++ b/test/allow_test.py
@@ -217,7 +217,7 @@ class TestTwice(object):
         teardown()
 
         assert re.match(
-            r"Allowed 'instance_method' to be called 2 times but was called 3 times on "
+            r"Allowed 'instance_method' to be called 2 times instead of 3 times on "
             r"<InstanceDouble of <class 'doubles.testing.User'> object at .+> "
             r"with any args, but was not."
             r" \(.*doubles/test/allow_test.py:\d+\)",
@@ -244,7 +244,7 @@ class TestOnce(object):
         teardown()
 
         assert re.match(
-            r"Allowed 'instance_method' to be called 1 time but was called 2 times on "
+            r"Allowed 'instance_method' to be called 1 time instead of 2 times on "
             r"<InstanceDouble of <class 'doubles.testing.User'> object at .+> "
             r"with any args, but was not."
             r" \(.*doubles/test/allow_test.py:\d+\)",
@@ -268,7 +268,7 @@ class TestZeroTimes(object):
         teardown()
 
         assert re.match(
-            r"Allowed 'instance_method' to be called 0 times but was called 1 "
+            r"Allowed 'instance_method' to be called 0 times instead of 1 "
             r"time on <InstanceDouble of <class 'doubles.testing.User'> "
             r"object at .+> with any args, but was not."
             r" \(.*doubles/test/allow_test.py:\d+\)",
@@ -299,7 +299,7 @@ class TestExactly(object):
         teardown()
 
         assert re.match(
-            r"Allowed 'instance_method' to be called 0 times but was called 1 "
+            r"Allowed 'instance_method' to be called 0 times instead of 1 "
             r"time on <InstanceDouble of <class 'doubles.testing.User'> "
             r"object at .+> with any args, but was not."
             r" \(.*doubles/test/allow_test.py:\d+\)",
@@ -339,7 +339,7 @@ class TestExactly(object):
         teardown()
 
         assert re.match(
-            r"Allowed 'instance_method' to be called 1 time but was called 2 times on "
+            r"Allowed 'instance_method' to be called 1 time instead of 2 times on "
             r"<InstanceDouble of <class 'doubles.testing.User'> object at .+> "
             r"with any args, but was not."
             r" \(.*doubles/test/allow_test.py:\d+\)",
@@ -447,7 +447,7 @@ class TestAtMost(object):
         teardown()
 
         assert re.match(
-            r"Allowed 'instance_method' to be called at most 1 time but was called 2 times on "
+            r"Allowed 'instance_method' to be called at most 1 time instead of 2 times on "
             r"<InstanceDouble of <class 'doubles.testing.User'> object at .+> "
             r"with any args, but was not."
             r" \(.*doubles/test/allow_test.py:\d+\)",

--- a/test/expect_test.py
+++ b/test/expect_test.py
@@ -126,7 +126,7 @@ class TestTwice(object):
         teardown()
 
         assert re.match(
-            r"Expected 'instance_method' to be called 2 times but was called 1 time on "
+            r"Expected 'instance_method' to be called 2 times instead of 1 time on "
             r"<InstanceDouble of <class 'doubles.testing.User'> object at .+> "
             r"with any args, but was not."
             r" \(.*doubles/test/expect_test.py:\d+\)",
@@ -145,7 +145,7 @@ class TestTwice(object):
         teardown()
 
         assert re.match(
-            r"Expected 'instance_method' to be called 2 times but was called 3 times on "
+            r"Expected 'instance_method' to be called 2 times instead of 3 times on "
             r"<InstanceDouble of <class 'doubles.testing.User'> object at .+> "
             r"with any args, but was not."
             r" \(.*doubles/test/expect_test.py:\d+\)",
@@ -172,7 +172,7 @@ class TestOnce(object):
         teardown()
 
         assert re.match(
-            r"Expected 'instance_method' to be called 1 time but was called 2 times on "
+            r"Expected 'instance_method' to be called 1 time instead of 2 times on "
             r"<InstanceDouble of <class 'doubles.testing.User'> object at .+> "
             r"with any args, but was not."
             r" \(.*doubles/test/expect_test.py:\d+\)",
@@ -207,7 +207,7 @@ class TestExactly(object):
         teardown()
 
         assert re.match(
-            r"Expected 'instance_method' to be called 2 times but was called 1 time on "
+            r"Expected 'instance_method' to be called 2 times instead of 1 time on "
             r"<InstanceDouble of <class 'doubles.testing.User'> object at .+> "
             r"with any args, but was not."
             r" \(.*doubles/test/expect_test.py:\d+\)",
@@ -232,7 +232,7 @@ class TestExactly(object):
         teardown()
 
         assert re.match(
-            r"Expected 'instance_method' to be called 1 time but was called 2 times on "
+            r"Expected 'instance_method' to be called 1 time instead of 2 times on "
             r"<InstanceDouble of <class 'doubles.testing.User'> object at .+> "
             r"with any args, but was not."
             r" \(.*doubles/test/expect_test.py:\d+\)",
@@ -259,7 +259,7 @@ class TestAtLeast(object):
         teardown()
 
         assert re.match(
-            r"Expected 'instance_method' to be called at least 2 times but was called 1 time on "
+            r"Expected 'instance_method' to be called at least 2 times instead of 1 time on "
             r"<InstanceDouble of <class 'doubles.testing.User'> object at .+> "
             r"with any args, but was not."
             r" \(.*doubles/test/expect_test.py:\d+\)",
@@ -317,7 +317,7 @@ class TestAtMost(object):
         teardown()
 
         assert re.match(
-            r"Expected 'instance_method' to be called at most 1 time but was called 2 times on "
+            r"Expected 'instance_method' to be called at most 1 time instead of 2 times on "
             r"<InstanceDouble of <class 'doubles.testing.User'> object at .+> "
             r"with any args, but was not."
             r" \(.*doubles/test/expect_test.py:\d+\)",
@@ -343,7 +343,7 @@ class Test__call__(object):
         teardown()
 
         assert re.match(
-            r"Expected '__call__' to be called 1 time but was called 0 times on "
+            r"Expected '__call__' to be called 1 time instead of 0 times on "
             r"<InstanceDouble of <class 'doubles.testing.User'> object at .+> "
             r"with any args, but was not."
             r" \(.*doubles/test/expect_test.py:\d+\)",
@@ -371,7 +371,7 @@ class Test__enter__(object):
         teardown()
 
         assert re.match(
-            r"Expected '__enter__' to be called 1 time but was called 0 times on "
+            r"Expected '__enter__' to be called 1 time instead of 0 times on "
             r"<InstanceDouble of <class 'doubles.testing.User'> object at .+> "
             r"with any args, but was not."
             r" \(.*doubles/test/expect_test.py:\d+\)",
@@ -399,7 +399,7 @@ class Test__exit__(object):
         teardown()
 
         assert re.match(
-            r"Expected '__exit__' to be called 1 time but was called 0 times on "
+            r"Expected '__exit__' to be called 1 time instead of 0 times on "
             r"<InstanceDouble of <class 'doubles.testing.User'> object at .+> "
             r"with any args, but was not."
             r" \(.*doubles/test/expect_test.py:\d+\)",

--- a/test/pytest_test.py
+++ b/test/pytest_test.py
@@ -38,7 +38,7 @@ def test_failed_expections_do_not_leak_between_tests(testdir, capsys):
     outcomes = result.parseoutcomes()
     assert outcomes['error'] == 2
     expected_error = (
-        "*Expected 'class_method' to be called 1 time but was called 0 times on"
+        "*Expected 'class_method' to be called 1 time instead of 0 times on"
         " <class 'doubles.testing.User'> with ('{arg_value}')*"
     )
     result.stdout.fnmatch_lines([expected_error.format(arg_value="test_one")])


### PR DESCRIPTION
Example: `Failed: Expected <method> to be called 1 time but was called 0 times on <object> with any args, but was not.`

Let's do something slightly more grammatically valid that is easy to generate from our existing functions. 

Possibly something like: `Failed: Expected <method> to be called 1 time instead of 0 times on <object> with any args, but was not`.