### PR TITLE
Fix  usage with Exceptions requiring arguments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
 
 install: make bootstrap
   - make bootstap
-  - if [ $TRAVIS_PYTHON_VERSION == 3.2 ]; then pip install pytest==2.9.1; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '3.2' ]]; then travis_retry pip install pytest==2.9.1; fi
 
 script: make
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ python:
 
 install: make bootstrap
   - make bootstap
-  # pytest 3+ does not support python 3.2
   - if [[ $TRAVIS_PYTHON_VERSION == 3.2 ]]; then pip install pytest==2.9.1; fi
 
 script: make

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
     - "3.5"
     - "3.6"
 
-install: make bootstrap
+install:
     - make bootstap
     - if [[ $TRAVIS_PYTHON_VERSION == '3.2' ]]; then travis_retry pip install pytest==2.9.1; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,19 @@
 language: python
 cache: pip
 python:
-  - "2.7"
-  - "3.2"
-  - "3.3"
-  - "3.4"
-  - "3.5"
-  - "3.6"
+    - "2.7"
+    - "3.2"
+    - "3.3"
+    - "3.4"
+    - "3.5"
+    - "3.6"
 
 install: make bootstrap
-  - make bootstap
-  - if [[ $TRAVIS_PYTHON_VERSION == '3.2' ]]; then travis_retry pip install pytest==2.9.1; fi
+    - make bootstap
+    - if [[ $TRAVIS_PYTHON_VERSION == '3.2' ]]; then travis_retry pip install pytest==2.9.1; fi
 
 script: make
 branches:
-  except:
-    - /^v[0-9]/
+    except:
+        - /^v[0-9]/
 after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
     - "3.6"
 
 install:
-    - make bootstap
+    - make bootstrap
     - if [[ $TRAVIS_PYTHON_VERSION == '3.2' ]]; then travis_retry pip install pytest==2.9.1; fi
 
 script: make

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
 
 install: make bootstrap
   - make bootstap
-  - if [[ $TRAVIS_PYTHON_VERSION == 3.2 ]]; then pip install pytest==2.9.1; fi
+  - if [ $TRAVIS_PYTHON_VERSION == 3.2 ]; then pip install pytest==2.9.1; fi
 
 script: make
 branches:

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -193,7 +193,7 @@ Both stubs and mocks allow a method call to raise an exception instead of return
         else:
             raise AssertionError('Expected test to raise StandardError.')
 
-If the exception to be raised requires arguments, they can be passed to ``and_raises`` directly::
+If the exception to be raised requires arguments, they can be passed to the Exception constructor directly before ``and_raises`` is invoked::
 
     from doubles import allow
 
@@ -203,7 +203,7 @@ If the exception to be raised requires arguments, they can be passed to ``and_ra
     def test_raising_an_exception():
         user = User('Carl')
 
-        allow(user).get_name.and_raise(NonStandardError, 'an argument', arg2='another arg')
+        allow(user).get_name.and_raise(NonStandardError('an argument', arg2='another arg'))
 
         try:
             user.get_name()

--- a/doubles/allowance.py
+++ b/doubles/allowance.py
@@ -71,7 +71,7 @@ class Allowance(object):
         :param Exception exception: The exception to raise.
         """
         def proxy_exception(*proxy_args, **proxy_kwargs):
-            raise exception(*args, **kwargs)
+            raise exception
 
         self._return_value = proxy_exception
         return self

--- a/test/return_values_test.py
+++ b/test/return_values_test.py
@@ -57,7 +57,8 @@ class TestReturnValues(object):
         subject = InstanceDouble('doubles.testing.User')
 
         stubber(subject).instance_method.and_raise(
-            UserDefinedExceptionWithArgs, 'msg', 'arg1', arg2='arg2')
+            UserDefinedExceptionWithArgs('msg', 'arg1', arg2='arg2'),
+        )
 
         with raises(UserDefinedExceptionWithArgs):
             subject.instance_method()


### PR DESCRIPTION
This should fix a backwards incompatible change with: https://github.com/uber/doubles/pull/107.

When passing in Exception instance (not classes) users were seeing:
`"'exceptions.Exception' object is not callable"`

