### PR TITLE
Better report doubles.verify failures in pytest

### DIFF
--- a/doubles/pytest_plugin.py
+++ b/doubles/pytest_plugin.py
@@ -2,11 +2,12 @@ import pytest
 
 from doubles.lifecycle import teardown, verify
 
-def pytest_runtest_call(item):
-    def verify_and_teardown_doubles():
-        try:
-            verify()
-        finally:
-            teardown()
+@pytest.hookimpl(hookwrapper=True)
+def pytest_pyfunc_call(pyfuncitem):
+    outcome = yield
 
-    item.addfinalizer(verify_and_teardown_doubles)
+    try:
+        outcome.get_result()
+        verify()
+    finally:
+        teardown()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -5,10 +5,7 @@ from coverage import coverage
 cov = coverage(source=('doubles',))
 cov.start()
 
-try:
-    from doubles.pytest_plugin import pytest_runtest_protocol  # noqa
-except ImportError:
-    from doubles.pytest_plugin import pytest_runtest_call  # noqa
+from doubles.pytest_plugin import pytest_pyfunc_call  # noqa
 
 
 def pytest_sessionfinish(session, exitstatus):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -5,7 +5,7 @@ from coverage import coverage
 cov = coverage(source=('doubles',))
 cov.start()
 
-from doubles.pytest_plugin import pytest_pyfunc_call  # noqa
+pytest_plugins = ['doubles.pytest_plugin']
 
 
 def pytest_sessionfinish(session, exitstatus):

--- a/test/pytest_test.py
+++ b/test/pytest_test.py
@@ -36,7 +36,7 @@ def test_failed_expections_do_not_leak_between_tests(testdir, capsys):
     """)
     result = testdir.runpytest()
     outcomes = result.parseoutcomes()
-    assert outcomes['error'] == 2
+    assert outcomes['failed'] == 2
     expected_error = (
         "*Expected 'class_method' to be called 1 time instead of 0 times on"
         " <class 'doubles.testing.User'> with ('{arg_value}')*"


### PR DESCRIPTION
* If doubles.verify finds unsatisfied expections, report the test as a
failure not an error.
* This should resolve: #126 