### PR TITLE
Fix linting and enable by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: test
-test: clean 
+test: clean lint
 	@py.test -s -p no:doubles test
 
 .PHONY: lint

--- a/doubles/pytest_plugin.py
+++ b/doubles/pytest_plugin.py
@@ -2,6 +2,7 @@ import pytest
 
 from doubles.lifecycle import teardown, verify
 
+
 @pytest.hookimpl(hookwrapper=True)
 def pytest_pyfunc_call(pyfuncitem):
     outcome = yield


### PR DESCRIPTION
In this PR linting violation is fixed and enabled in `make test` by default.